### PR TITLE
Add cross-platform startup script support

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -2,5 +2,6 @@ ADMIN_ROLE_NAME="Name of the Discord role that has admin privileges"
 DISCORD_TOKEN="The bot’s secret token from the Discord Developer Portal"
 DISCORD_CLIENT_ID="The bot’s client ID from the Discord Developer Portal"
 DISCORD_GUILD_ID="The Discord server's guild ID from the server"
-MC_SERVER_SCRIPT_LOCATION="E:/Minecraft Servers/_zaaras world"
-MC_SERVER_SCRIPT_NAME="server_start.bat"
+MC_SERVER_SCRIPT_LOCATION="Path to the folder containing your Minecraft server"
+# Uncomment and set this only if you renamed your start script.
+#MC_SERVER_SCRIPT_NAME="server_start.bat or server_start.sh"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # MinecraftBot for Discord Servers
-A Discord bot developed using [Discord.js](https://discord.js.org/#/) specifically for Windows machine to help seamlessly interact with a Minecraft server remotely using Discord servers. Server members can request for the host's IP and server population. Admin privileges can be set up using Discord roles.
+A Discord bot developed using [Discord.js](https://discord.js.org/#/) to seamlessly interact with a Minecraft server remotely using Discord servers. Runs on Windows, Linux, and macOS. Server members can request the host's IP and server population. Admin privileges can be set up using Discord roles.
 
 ## Usage
 * `/start-server` : Remotely start the Minecraft server.
@@ -18,9 +18,11 @@ A Discord bot developed using [Discord.js](https://discord.js.org/#/) specifical
 ## Installation guide
 1. Clone this repository.
 
-1. Move `server_start.bat` to the folder containing the Minecraft server.
-    1. (Optional) Change the [minimum and maximum RAM allocated](https://minecraft.gamepedia.com/Tutorials/Setting_up_a_server#Java_options) in [server_start.bat](https://github.com/PSYmoom/MinecraftBot/blob/master/server_start.bat#L1) to a value of your choice.
-    1. (Note) You can also reuse your own .bat file. Please remove any pause commands if this is the case. Changing `MC_SERVER_SCRIPT_NAME` will become mandatory in this case!
+1. Move the start script to the folder containing the Minecraft server:
+    1. On Windows, copy `server_start.bat`.
+    1. On Linux/macOS, copy `server_start.sh` and run `chmod +x server_start.sh` so it can execute.
+    1. (Optional) Change the [minimum and maximum RAM allocated](https://minecraft.gamepedia.com/Tutorials/Setting_up_a_server#Java_options) in the script to a value of your choice.
+    1. (Note) You can reuse your own start script. Please remove any pause commands if this is the case. If you renamed the script, set `MC_SERVER_SCRIPT_NAME` in `.env` to match.
 
 1. Change `ADMIN_ROLE_NAME` in [.env_sample](https://github.com/PSYmoom/MinecraftBot/blob/master/.env_sample#L1) to match the role of admins in your server.
 
@@ -30,17 +32,21 @@ A Discord bot developed using [Discord.js](https://discord.js.org/#/) specifical
 
 1. Change `DISCORD_GUILD_ID` in [.env_sample](https://github.com/PSYmoom/MinecraftBot/blob/master/.env_sample#L4) to match your Discord server's guild ID.
 
-1. Change `MC_SERVER_SCRIPT_LOCATION` in [.env_sample](https://github.com/PSYmoom/MinecraftBot/blob/master/.env_sample#L5) to match the directory of your `server_start.bat`.
+1. Change `MC_SERVER_SCRIPT_LOCATION` in [.env_sample](https://github.com/PSYmoom/MinecraftBot/blob/master/.env_sample#L5) to match the directory of your start script.
 
-1. Change `MC_SERVER_SCRIPT_NAME` in [.env_sample](https://github.com/PSYmoom/MinecraftBot/blob/master/.env_sample#L6) to match the filename of your starting script `server_start.bat`.
+1. (Optional) Set `MC_SERVER_SCRIPT_NAME` in [.env_sample](https://github.com/PSYmoom/MinecraftBot/blob/master/.env_sample) only if you renamed your start script. The bot defaults to `server_start.bat` on Windows and `./server_start.sh` on Linux/macOS.
 
 1. Rename `.env_sample` file to `.env`.
 
 1. The set up is complete! Use `npm install` and `npm run start` from the Discord Bot's location to start the bot.
 
 1. (Optional) Alternatively, you can set up the bot to automatically start when your host machine is booted up.
+
+    **Windows:**
     1. Open Run and enter `shell:startup`.
-  
     1. Move [MinecraftBotStartUp.bat](https://github.com/PSYmoom/MinecraftBot/blob/master/MinecraftBotStartUp.bat) to the folder that opens up.
-  
-    1. Change the location in [MinecraftBotStartUp.bat](https://github.com/PSYmoom/MinecraftBot/blob/master/server_start.bat#L2) to match the location of your Discord Bot. 
+    1. Change the location in [MinecraftBotStartUp.bat](https://github.com/PSYmoom/MinecraftBot/blob/master/MinecraftBotStartUp.bat) to match the location of your Discord Bot.
+
+    **Linux:**
+    1. Recommended: create a `systemd` user/service unit that runs `npm run start` from the bot directory.
+    1. Alternative: launch the bot inside a `tmux` or `screen` session so it survives logging out of SSH.

--- a/server_start.sh
+++ b/server_start.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+java -Xmx12G -Xms1024M -jar <server name> nogui

--- a/utility/minecraft-server.js
+++ b/utility/minecraft-server.js
@@ -36,10 +36,13 @@ class MinecraftServer {
         // Create a child process
         await interaction.reply('Starting server...');
 
-        this.#proc = spawn(process.env.MC_SERVER_SCRIPT_NAME, { 
+        const defaultScript = process.platform === 'win32' ? 'server_start.bat' : './server_start.sh';
+        const scriptName = process.env.MC_SERVER_SCRIPT_NAME || defaultScript;
+
+        this.#proc = spawn(scriptName, {
             cwd: process.env.MC_SERVER_SCRIPT_LOCATION,
             shell: true
-        }); 
+        });
 
         // Set up logging to console
         this.#attachLogging();


### PR DESCRIPTION
Auto-pick server_start.bat on Windows and ./server_start.sh on Linux/macOS, with MC_SERVER_SCRIPT_NAME retained as an optional override. Adds the .sh script, updates .env_sample to a generic placeholder, and reworks the README install/autostart steps to cover both platforms.