### PR TITLE
Add multi-server registry with auto-discovery and per-server commands

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -2,6 +2,11 @@ ADMIN_ROLE_NAME="Name of the Discord role that has admin privileges"
 DISCORD_TOKEN="The bot’s secret token from the Discord Developer Portal"
 DISCORD_CLIENT_ID="The bot’s client ID from the Discord Developer Portal"
 DISCORD_GUILD_ID="The Discord server's guild ID from the server"
-MC_SERVER_SCRIPT_LOCATION="Path to the folder containing your Minecraft server"
-# Uncomment and set this only if you renamed your start script.
-#MC_SERVER_SCRIPT_NAME="server_start.bat or server_start.sh"
+# Root folder containing all your Minecraft server subdirectories.
+# Each subfolder becomes a discoverable server (named after the folder).
+# Each subfolder must contain server_start.bat (Windows) or server_start.sh (Linux/macOS),
+# and typically a server.properties (used to read the server-port).
+# Examples:
+#   Windows:     "E:/Minecraft Servers/"
+#   Linux/macOS: "/home/user/minecraft_servers/"
+MC_SERVERS_ROOT="Path to the folder containing your Minecraft server subdirectories"

--- a/MinecraftBot.js
+++ b/MinecraftBot.js
@@ -1,8 +1,9 @@
 import { Client, Collection, Events, GatewayIntentBits } from 'discord.js';
 import dotenv from 'dotenv';
 
-import { initMinecraftServer } from './utility/minecraft-server.js';
+import { initServerRegistry } from './utility/server-registry.js';
 import { reloadCommands } from './utility/reload-commands.js';
+import { registerAutocomplete } from './utility/register-autocomplete.js';
 
 // Import env variables
 dotenv.config();
@@ -20,9 +21,8 @@ client.commands = new Collection();
 
 client.once(Events.ClientReady, async (readyClient) => {
     await reloadCommands(client);
-    // Initialize minecraftServer instance once bot is ready
-
-    initMinecraftServer(client);
+    initServerRegistry(client);
+    registerAutocomplete(client);
 
     console.log(`Ready! Logged in as ${readyClient.user.tag}`);
 });

--- a/README.md
+++ b/README.md
@@ -1,12 +1,38 @@
 # MinecraftBot for Discord Servers
-A Discord bot developed using [Discord.js](https://discord.js.org/#/) to seamlessly interact with a Minecraft server remotely using Discord servers. Runs on Windows, Linux, and macOS. Server members can request the host's IP and server population. Admin privileges can be set up using Discord roles.
+A Discord bot developed using [Discord.js](https://discord.js.org/#/) to seamlessly manage one or more Minecraft servers remotely from Discord. Runs on Windows, Linux, and macOS. Server members can request the host's IP and server population. Admin privileges can be set up using Discord roles.
 
 ## Usage
-* `/start-server` : Remotely start the Minecraft server.
-* `/server-stop` : Remotely stop the Minecraft server.
-* `/fetch-ip` : Request the public IP of the host of Minecraft server.
-* `/execute <command>` : Remotely send a command to the server (Admin privileges required).
-* `/players` : Check who are playing currently on the Minecraft server.
+* `/start-server <server>` : Remotely start a Minecraft server.
+* `/stop-server <server>` : Remotely stop a Minecraft server.
+* `/execute <server> <command>` : Remotely send a command to a server (admin privileges required).
+* `/players <server>` : Check who is playing currently on a server.
+* `/fetch-ip` : Request the public IP of the host.
+* `/list-servers` : Show all configured servers with their type, port, and state.
+* `/reload-servers` : Re-scan `MC_SERVERS_ROOT` for new/removed folders (admin privileges required).
+
+The `<server>` argument is auto-completed in Discord.
+
+## Server layout
+Point `MC_SERVERS_ROOT` at a parent folder containing one subfolder per Minecraft server. The bot names each server after its folder and inspects the contents to figure out the rest.
+
+```
+MC_SERVERS_ROOT/
+  vanilla_world/
+    server_start.bat   (or server_start.sh on Linux/macOS)
+    server.properties
+    server.jar
+  modded_world/
+    server_start.bat
+    server.properties
+    forge-1.20.1-47.4.0.jar
+    mods/
+```
+
+* **Type**: `modded` if the folder contains a `forge-*.jar`, `fabric-server-launch.jar`, or a non-empty `mods/`; otherwise `vanilla`. Modded servers use looser boot-output checks (Forge emits non-fatal errors during startup).
+* **Port**: read from `server-port=` in `server.properties` (default `25565`). Duplicate ports across folders log a warning at startup.
+* **Skip**: folders missing the platform's start script are ignored.
+
+Add a server by creating a folder and calling `/reload-servers`.
 
 ## Prerequisites
 1. [Install Node.js and discord.js](https://discordjs.guide/preparations/)
@@ -18,11 +44,11 @@ A Discord bot developed using [Discord.js](https://discord.js.org/#/) to seamles
 ## Installation guide
 1. Clone this repository.
 
-1. Move the start script to the folder containing the Minecraft server:
+1. For each Minecraft server you want the bot to manage, create a subfolder under your `MC_SERVERS_ROOT` and copy the appropriate start script into it:
     1. On Windows, copy `server_start.bat`.
-    1. On Linux/macOS, copy `server_start.sh` and run `chmod +x server_start.sh` so it can execute.
+    1. On Linux/macOS, copy `server_start.sh` and run `chmod +x server_start.sh`.
     1. (Optional) Change the [minimum and maximum RAM allocated](https://minecraft.gamepedia.com/Tutorials/Setting_up_a_server#Java_options) in the script to a value of your choice.
-    1. (Note) You can reuse your own start script. Please remove any pause commands if this is the case. If you renamed the script, set `MC_SERVER_SCRIPT_NAME` in `.env` to match.
+    1. Make sure each server's `server.properties` has a unique `server-port=` so they don't collide.
 
 1. Change `ADMIN_ROLE_NAME` in [.env_sample](https://github.com/PSYmoom/MinecraftBot/blob/master/.env_sample#L1) to match the role of admins in your server.
 
@@ -32,15 +58,13 @@ A Discord bot developed using [Discord.js](https://discord.js.org/#/) to seamles
 
 1. Change `DISCORD_GUILD_ID` in [.env_sample](https://github.com/PSYmoom/MinecraftBot/blob/master/.env_sample#L4) to match your Discord server's guild ID.
 
-1. Change `MC_SERVER_SCRIPT_LOCATION` in [.env_sample](https://github.com/PSYmoom/MinecraftBot/blob/master/.env_sample#L5) to match the directory of your start script.
+1. Change `MC_SERVERS_ROOT` in [.env_sample](https://github.com/PSYmoom/MinecraftBot/blob/master/.env_sample#L12) to the absolute path of the parent folder containing your Minecraft server subdirectories.
 
-1. (Optional) Set `MC_SERVER_SCRIPT_NAME` in [.env_sample](https://github.com/PSYmoom/MinecraftBot/blob/master/.env_sample) only if you renamed your start script. The bot defaults to `server_start.bat` on Windows and `./server_start.sh` on Linux/macOS.
+1. Rename `.env_sample` to `.env`.
 
-1. Rename `.env_sample` file to `.env`.
+1. Setup is complete. Use `npm install` and `npm run start` from the Discord Bot's location to start the bot.
 
-1. The set up is complete! Use `npm install` and `npm run start` from the Discord Bot's location to start the bot.
-
-1. (Optional) Alternatively, you can set up the bot to automatically start when your host machine is booted up.
+1. (Optional) Set up the bot to automatically start when your host machine boots:
 
     **Windows:**
     1. Open Run and enter `shell:startup`.

--- a/commands/execute/execute.js
+++ b/commands/execute/execute.js
@@ -1,6 +1,6 @@
-import { SlashCommandBuilder, PermissionFlagsBits } from 'discord.js';
+import { SlashCommandBuilder } from 'discord.js';
 
-import { minecraftServer } from '../../utility/minecraft-server.js';
+import { getServer } from '../../utility/server-registry.js';
 
 // Toggle to enforce ADMIN_ROLE_NAME checking
 export const requireAdminRole = true;
@@ -9,19 +9,34 @@ export const requireAdminRole = true;
 export function createData(requiredMemberPermissions = null) {
     return new SlashCommandBuilder()
         .setName('execute')
-        .setDescription('Remotely send a command for the server to execute')
+        .setDescription('Remotely send a command for a Minecraft server to execute')
         .setDefaultMemberPermissions(requiredMemberPermissions)
-        .addStringOption((option) => option.setName('command').setDescription('Command to be executed').setRequired(true));
+        .addStringOption((option) =>
+            option.setName('server')
+                .setDescription('Which Minecraft server to send the command to')
+                .setRequired(true)
+                .setAutocomplete(true))
+        .addStringOption((option) =>
+            option.setName('command')
+                .setDescription('Command to be executed')
+                .setRequired(true));
 }
 
 // Function executed by listener
 export async function execute(interaction) {
-    if (!minecraftServer.isRunning()) {
-        // Ensures the server is running
-        await interaction.reply("Server is not on!");
+    const name = interaction.options.getString('server');
+    const server = getServer(name);
+
+    if (!server) {
+        await interaction.reply(`Unknown server: \`${name}\`.`);
+        return;
+    }
+
+    if (!server.isRunning()) {
+        await interaction.reply(`Server **${name}** is not on!`);
         return;
     }
 
     const command = interaction.options.getString('command').trim();
-    await minecraftServer.execute(interaction, command);
+    await server.execute(interaction, command);
 }

--- a/commands/listServers/list-servers.js
+++ b/commands/listServers/list-servers.js
@@ -1,0 +1,33 @@
+import { SlashCommandBuilder } from 'discord.js';
+
+import { listServers } from '../../utility/server-registry.js';
+
+// Toggle to enforce ADMIN_ROLE_NAME checking
+export const requireAdminRole = false;
+
+// Command definition
+export function createData(requiredMemberPermissions = null) {
+    return new SlashCommandBuilder()
+        .setName('list-servers')
+        .setDescription('Show all configured Minecraft servers and their current state')
+        .setDefaultMemberPermissions(requiredMemberPermissions);
+}
+
+// Function executed by listener
+export async function execute(interaction) {
+    const servers = listServers();
+
+    if (servers.length === 0) {
+        await interaction.reply('No servers are currently configured. Check `MC_SERVERS_ROOT` and try `/reload-servers`.');
+        return;
+    }
+
+    const nameWidth = Math.max(...servers.map(s => s.name.length));
+    const typeWidth = Math.max(...servers.map(s => s.type.length));
+
+    const lines = servers.map(s =>
+        `${s.name.padEnd(nameWidth)}  [${s.type.padEnd(typeWidth)}]  port ${s.port}  —  ${s.state}`
+    );
+
+    await interaction.reply('```\n' + lines.join('\n') + '\n```');
+}

--- a/commands/players/players.js
+++ b/commands/players/players.js
@@ -1,6 +1,6 @@
 import { SlashCommandBuilder } from 'discord.js';
 
-import { minecraftServer } from '../../utility/minecraft-server.js';
+import { getServer } from '../../utility/server-registry.js';
 
 // Toggle to enforce ADMIN_ROLE_NAME checking
 export const requireAdminRole = false;
@@ -9,17 +9,29 @@ export const requireAdminRole = false;
 export function createData(requiredMemberPermissions = null) {
     return new SlashCommandBuilder()
         .setName('players')
-        .setDescription('Check who are playing currently on the Minecraft server')
-        .setDefaultMemberPermissions(requiredMemberPermissions);
+        .setDescription('Check who is playing currently on a Minecraft server')
+        .setDefaultMemberPermissions(requiredMemberPermissions)
+        .addStringOption((option) =>
+            option.setName('server')
+                .setDescription('Which Minecraft server to query')
+                .setRequired(true)
+                .setAutocomplete(true));
 }
 
 // Function executed by listener
 export async function execute(interaction) {
-    if (!minecraftServer.isRunning()) {
-        // Ensures the server is running
-        await interaction.reply("Server is not on!");
+    const name = interaction.options.getString('server');
+    const server = getServer(name);
+
+    if (!server) {
+        await interaction.reply(`Unknown server: \`${name}\`.`);
         return;
     }
 
-    await minecraftServer.execute(interaction, 'list');
+    if (!server.isRunning()) {
+        await interaction.reply(`Server **${name}** is not on!`);
+        return;
+    }
+
+    await server.execute(interaction, 'list');
 }

--- a/commands/reloadServers/reload-servers.js
+++ b/commands/reloadServers/reload-servers.js
@@ -1,0 +1,28 @@
+import { SlashCommandBuilder } from 'discord.js';
+
+import { reloadRegistry } from '../../utility/server-registry.js';
+
+// Toggle to enforce ADMIN_ROLE_NAME checking
+export const requireAdminRole = true;
+
+// Command definition
+export function createData(requiredMemberPermissions = null) {
+    return new SlashCommandBuilder()
+        .setName('reload-servers')
+        .setDescription('Re-scan MC_SERVERS_ROOT for new or removed server folders')
+        .setDefaultMemberPermissions(requiredMemberPermissions);
+}
+
+// Function executed by listener
+export async function execute(interaction) {
+    const { added, removed, orphaned } = reloadRegistry();
+
+    const parts = ['Registry reloaded.'];
+    parts.push(added.length ? `Added: ${added.join(', ')}` : 'Added: (none)');
+    parts.push(removed.length ? `Removed: ${removed.join(', ')}` : 'Removed: (none)');
+    if (orphaned.length) {
+        parts.push(`Orphaned (still running but folder missing): ${orphaned.join(', ')}`);
+    }
+
+    await interaction.reply(parts.join('\n'));
+}

--- a/commands/startServer/start-server.js
+++ b/commands/startServer/start-server.js
@@ -1,6 +1,6 @@
 import { SlashCommandBuilder } from 'discord.js';
 
-import { minecraftServer } from '../../utility/minecraft-server.js';
+import { getServer } from '../../utility/server-registry.js';
 
 // Toggle to enforce ADMIN_ROLE_NAME checking
 export const requireAdminRole = false;
@@ -9,23 +9,34 @@ export const requireAdminRole = false;
 export function createData(requiredMemberPermissions = null) {
     return new SlashCommandBuilder()
         .setName('start-server')
-        .setDescription('Remotely start the Minecraft server')
-        .setDefaultMemberPermissions(requiredMemberPermissions);
+        .setDescription('Remotely start a Minecraft server')
+        .setDefaultMemberPermissions(requiredMemberPermissions)
+        .addStringOption((option) =>
+            option.setName('server')
+                .setDescription('Which Minecraft server to start')
+                .setRequired(true)
+                .setAutocomplete(true));
 }
 
 // Function executed by listener
 export async function execute(interaction) {
-    if (minecraftServer.isBusy()) {
-        // Ensures that no operation is currently being ran on the server
-        await interaction.reply('Server is bust right now! Please wait for the current process to finish executing.');
-        return;
-    } 
+    const name = interaction.options.getString('server');
+    const server = getServer(name);
 
-    if (!minecraftServer.isStopped()) {
-        // Ensures the server is stopped
-        await interaction.reply('Server is already on!');
+    if (!server) {
+        await interaction.reply(`Unknown server: \`${name}\`.`);
         return;
     }
 
-    await minecraftServer.start(interaction);
+    if (server.isBusy()) {
+        await interaction.reply(`Server **${name}** is busy right now! Please wait for the current process to finish executing.`);
+        return;
+    }
+
+    if (!server.isStopped()) {
+        await interaction.reply(`Server **${name}** is already on!`);
+        return;
+    }
+
+    await server.start(interaction);
 }

--- a/commands/stopServer/stop-server.js
+++ b/commands/stopServer/stop-server.js
@@ -1,31 +1,42 @@
 import { SlashCommandBuilder } from 'discord.js';
 
-import { minecraftServer } from '../../utility/minecraft-server.js';
+import { getServer } from '../../utility/server-registry.js';
 
 // Toggle to enforce ADMIN_ROLE_NAME checking
 export const requireAdminRole = false;
 
-// Command 
+// Command definition
 export function createData(requiredMemberPermissions = null) {
     return new SlashCommandBuilder()
         .setName('stop-server')
-        .setDescription('Remotely stop the Minecraft server')
-            .setDefaultMemberPermissions(requiredMemberPermissions);
+        .setDescription('Remotely stop a Minecraft server')
+        .setDefaultMemberPermissions(requiredMemberPermissions)
+        .addStringOption((option) =>
+            option.setName('server')
+                .setDescription('Which Minecraft server to stop')
+                .setRequired(true)
+                .setAutocomplete(true));
 }
 
 // Function executed by listener
 export async function execute(interaction) {
-    if (minecraftServer.isBusy()) {
-        // Ensures that no operation is currently being ran on the server
-        await interaction.reply('Server is busy right now! Please wait for the current process to finish executing.');
-        return;
-    } 
+    const name = interaction.options.getString('server');
+    const server = getServer(name);
 
-    if (!minecraftServer.isRunning()) {
-        // Ensures the server is running
-        await interaction.reply("Server is not on!");
+    if (!server) {
+        await interaction.reply(`Unknown server: \`${name}\`.`);
         return;
     }
 
-    await minecraftServer.stop(interaction);
+    if (server.isBusy()) {
+        await interaction.reply(`Server **${name}** is busy right now! Please wait for the current process to finish executing.`);
+        return;
+    }
+
+    if (!server.isRunning()) {
+        await interaction.reply(`Server **${name}** is not on!`);
+        return;
+    }
+
+    await server.stop(interaction);
 }

--- a/utility/change-status.js
+++ b/utility/change-status.js
@@ -3,16 +3,34 @@ export const ServerState = Object.freeze({
     STARTING: "Server is STARTING 🟡",
     STOPPING: "Server is SHUTTING DOWN 🟡",
     STOPPED: "Server is OFFLINE 🔴"
-})
+});
 
 /**
- * Updates the bot's presence.
- * @param user - The Discord Bot's user instance
- * @param status - An element from ServerState
+ * Updates the bot's presence based on the aggregate state of every server in the registry.
+ * @param user - The Discord Bot's user instance.
+ * @param servers - Array of MinecraftServer instances.
  */
-export async function setPresence(user, status) {
-  await user.setPresence({
-    activities: [{name: status, type: 0}],
-  });
+export async function setAggregatePresence(user, servers) {
+    if (!user) return;
+
+    const total = servers.length;
+
+    if (total === 0) {
+        await user.setPresence({ activities: [{ name: '🔴 No servers configured', type: 0 }] });
+        return;
+    }
+
+    const running = servers.filter(s => s.isRunning()).length;
+    const transitioning = servers.some(s => s.isBusy());
+
+    let name;
+    if (transitioning) {
+        name = `🟡 ${running}/${total} running (transitioning)`;
+    } else if (running > 0) {
+        name = `🟢 ${running}/${total} server${total > 1 ? 's' : ''} running`;
+    } else {
+        name = `🔴 All servers offline (0/${total})`;
+    }
+
+    await user.setPresence({ activities: [{ name, type: 0 }] });
 }
- 

--- a/utility/minecraft-server.js
+++ b/utility/minecraft-server.js
@@ -1,30 +1,39 @@
 import { once } from 'events';
-import process from 'process';
 import { MessageFlags } from 'discord.js';
 import { spawn } from 'child_process';
 
-import { ServerState, setPresence } from './change-status.js';
+import { ServerState } from './change-status.js';
 
 // --- Class ---
-class MinecraftServer {
+export class MinecraftServer {
     // --- Attributes ---
     #proc;
     #state;
-    #bot;
+    #config;
+    #onStateChange;
 
     // --- Constructor ---
-    constructor(user) {
+    /**
+     * @param {object} config - { name, location, scriptName, port, type }
+     * @param {(server: MinecraftServer) => void} [onStateChange] - Invoked after every state transition.
+     */
+    constructor(config, onStateChange) {
         this.#proc = null;
-        this.#bot = user;
+        this.#config = config;
+        this.#onStateChange = onStateChange;
         this.#updateStatus(ServerState.STOPPED);
     }
 
     // --- Public methods ---
+    getName() { return this.#config.name; }
+    getState() { return this.#state; }
+    getConfig() { return this.#config; }
+
     /**
      * Starts the Minecraft server process.
-     * - Spawns the server_start.bat script as a child process.
+     * - Spawns the per-server start script as a child process.
      * - Wires up stdout/stderr logging and unexpected exit/error handlers.
-     * - Sets internal state to either STARTED or STOPPED based on outcome of start up.
+     * - Sets internal state to either RUNNING or STOPPED based on outcome of start up.
      *
      * Notes:
      * - Notifies the Discord interaction of progress in various steps of the way
@@ -34,13 +43,10 @@ class MinecraftServer {
         this.#updateStatus(ServerState.STARTING);
 
         // Create a child process
-        await interaction.reply('Starting server...');
+        await interaction.reply(`Starting server **${this.#config.name}**...`);
 
-        const defaultScript = process.platform === 'win32' ? 'server_start.bat' : './server_start.sh';
-        const scriptName = process.env.MC_SERVER_SCRIPT_NAME || defaultScript;
-
-        this.#proc = spawn(scriptName, {
-            cwd: process.env.MC_SERVER_SCRIPT_LOCATION,
+        this.#proc = spawn(this.#config.scriptName, {
+            cwd: this.#config.location,
             shell: true
         });
 
@@ -57,7 +63,7 @@ class MinecraftServer {
 
     /**
      * Stops the Minecraft server process gracefully.
-     * - Sends "stop" command to the server’s stdin.
+     * - Sends "stop" command to the server's stdin.
      * - Logs and reports exit code/signal.
      * - Cleans up internal attributes
      *
@@ -70,16 +76,16 @@ class MinecraftServer {
 
         // Set up listener to catch the process exit event 
         this.#proc.once('exit', async (code, signal) => {
-            console.log(this.#errorStatement(code, signal));
+            console.log(`[${this.#config.name}] ${this.#errorStatement(code, signal)}`);
             await interaction.followUp(this.#errorStatement(code, signal));
             this.#cleanup();
         });
 
         // Send the stop signal to the child process
-        await interaction.reply("Stopping server...");
+        await interaction.reply(`Stopping server **${this.#config.name}**...`);
         this.#proc.stdin.write('stop\n');
-
     }
+
     /**
      * Executes a command on the running Minecraft server.
      *
@@ -88,7 +94,7 @@ class MinecraftServer {
      *   which works reliably for most commands
      */
     async execute(interaction, command) {
-        console.log(`${command} command executed by ${interaction.user.username}`);
+        console.log(`[${this.#config.name}] ${command} command executed by ${interaction.user.username}`);
         this.#forwardLogs(interaction);
         this.#proc.stdin.write(command.trim() + '\n');
     }
@@ -117,29 +123,32 @@ class MinecraftServer {
         return this.#state == ServerState.STOPPED;
     }
 
-    //  --- Private methods ---
-    async #updateStatus(serverState) {
-        this.#state = serverState;
-        setPresence(this.#bot, serverState);
+    // --- Private methods ---
+    #isVanilla() {
+        return this.#config.type === 'vanilla';
     }
 
-    async #attachLogging() {
-        if (!this.#proc)
-            return;
+    #updateStatus(serverState) {
+        this.#state = serverState;
+        if (this.#onStateChange) this.#onStateChange(this);
+    }
+
+    #attachLogging() {
+        if (!this.#proc) return;
 
         this.#proc.stdout.on('data', line => {
-            console.log(`stdout: ${line.toString().trim()}`);
+            console.log(`[${this.#config.name}] stdout: ${line.toString().trim()}`);
         });
 
         this.#proc.stderr.on('data', line => {
-            console.error(`stderr: ${line.toString().trim()}`);
+            console.error(`[${this.#config.name}] stderr: ${line.toString().trim()}`);
         });
     }
 
     #onUnexpectedExit() {
         this.#proc.once('exit', (code, signal) => {
             if (this.#state != ServerState.STOPPING) {
-                console.log(this.#errorStatement(code, signal));
+                console.log(`[${this.#config.name}] ${this.#errorStatement(code, signal)}`);
                 // TODO: Send unexpected message to appropriate channel
                 this.#cleanup();
             }
@@ -148,15 +157,14 @@ class MinecraftServer {
 
     #onUnexpectedError() {
         this.#proc.once('error', (err) => {
-            console.log(err);
+            console.log(`[${this.#config.name}]`, err);
             // TODO: Send unexpected message to appropriate channel
             this.#cleanup();
         });
     }
 
     #cleanup() {
-        if (!this.#proc)
-            return;
+        if (!this.#proc) return;
 
         this.#proc.stdout.removeAllListeners('data');
         this.#proc.stderr.removeAllListeners('data');
@@ -169,12 +177,12 @@ class MinecraftServer {
 
     #errorStatement(code, signal) {
         let suffix = code != null ? `${code}` : `signal ${signal}`;
-        return `Minecraft Server exited with code ${suffix}`;
+        return `Minecraft Server **${this.#config.name}** exited with code ${suffix}`;
     }
 
-    // Wait for either "help" on stdout OR first stderr event
+    // Wait for either "help" on stdout (vanilla) / "Server Backup done!" (modded) OR first stderr event
     async #monitorStartup(interaction) {
-        var response = {
+        const response = {
             content: '',
             flags: MessageFlags.Ephemeral,
         };
@@ -182,7 +190,7 @@ class MinecraftServer {
         try {
             response.content = await this.#startRace();
             this.#updateStatus(ServerState.RUNNING);
-            await interaction.followUp(response.content);
+            await interaction.followUp(`**${this.#config.name}**: ${response.content}`);
         } catch (error) {
             this.#proc = null;
             this.#updateStatus(ServerState.STOPPED);
@@ -199,12 +207,16 @@ class MinecraftServer {
     }
 
     async #monitorStartupStdout() {
+        // Modded (Forge) servers log differently and emit non-fatal errors during boot.
+        // Vanilla finishes boot when the help banner prints; Forge prints "Server Backup done!".
+        const completionMarker = this.#isVanilla() ? '"help"' : 'Server Backup done!';
+
         while (this.#state == ServerState.STARTING) {
             let line = await once(this.#proc.stdout, 'data');
             line = line.toString().trim();
-            if (line.endsWith('"help"')) {
+            if (line.endsWith(completionMarker)) {
                 return 'Server open!';
-            } else if (line.includes('ERROR')) {
+            } else if (this.#isVanilla() && line.includes('ERROR')) {
                 throw new Error('Error encountered during startup! Please check console for more details');
             }
         }
@@ -214,8 +226,9 @@ class MinecraftServer {
         while (this.#state == ServerState.STARTING) {
             let line = await once(this.#proc.stderr, 'data');
             line = line.toString().trim();
-            // Ignores warnings
-            if (!line.includes('WARNING')) {
+            // Vanilla treats any non-WARNING stderr line as fatal. Modded servers
+            // emit lots of harmless stderr chatter during boot, so we ignore it.
+            if (this.#isVanilla() && !line.includes('WARNING')) {
                 throw new Error('stderr: ' + line);
             }
         }
@@ -224,7 +237,7 @@ class MinecraftServer {
     // Forwards all logs collected to Discord during durationMs
     async #forwardLogs(interaction, durationMs = 500) {
         const end = Date.now() + durationMs;
-        let log = 'Command executed successfully! Here is the relevent log output:\n';
+        let log = 'Command executed successfully! Here is the relevant log output:\n';
 
         while (Date.now() < end) {
             const timeout = end - Date.now();
@@ -232,10 +245,7 @@ class MinecraftServer {
                 once(this.#proc.stdout, 'data'),
                 new Promise(resolve => setTimeout(resolve, timeout))]);
 
-                if (!line) {
-                // Timed out
-                break;
-            }
+            if (!line) break;
 
             log += line.toString().trim() + '\n';
         }
@@ -247,20 +257,5 @@ class MinecraftServer {
         }
 
         await interaction.reply(log);
-        return;
     }
-}
-
-export let minecraftServer;
-
-/**
- * Initialize the MinecraftServer instance.
- * Call this once the Discord client is ready.
- */
-export function initMinecraftServer(client) {
-    if (!client?.user) {
-        throw new Error('Client is not ready. Presence cannot be set.');
-    }
-
-    minecraftServer = new MinecraftServer(client.user);
 }

--- a/utility/register-autocomplete.js
+++ b/utility/register-autocomplete.js
@@ -1,0 +1,26 @@
+import { Events } from 'discord.js';
+
+import { serverNames } from './server-registry.js';
+
+/**
+ * Wires the autocomplete handler for the `server` option used across multiple
+ * slash commands. Discord caps autocomplete responses at 25 choices.
+ */
+export function registerAutocomplete(client) {
+    client.on(Events.InteractionCreate, async (interaction) => {
+        if (!interaction.isAutocomplete()) return;
+        if (interaction.options.getFocused(true).name !== 'server') return;
+
+        const focused = interaction.options.getFocused().toLowerCase();
+        const choices = serverNames()
+            .filter(n => n.toLowerCase().includes(focused))
+            .slice(0, 25)
+            .map(name => ({ name, value: name }));
+
+        try {
+            await interaction.respond(choices);
+        } catch (err) {
+            console.error('[autocomplete] respond failed:', err);
+        }
+    });
+}

--- a/utility/server-registry.js
+++ b/utility/server-registry.js
@@ -1,0 +1,170 @@
+import { readdirSync, existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import process from 'process';
+
+import { MinecraftServer } from './minecraft-server.js';
+import { setAggregatePresence } from './change-status.js';
+
+const registry = new Map();
+let botUser = null;
+
+/**
+ * Scans MC_SERVERS_ROOT and returns an array of config objects, one per
+ * eligible subdirectory. Subdirectories without a platform-appropriate start
+ * script are skipped.
+ * @returns {Array<{name: string, location: string, scriptName: string, port: number, type: 'vanilla'|'modded'}>}
+ */
+export function discoverServers() {
+    const root = process.env.MC_SERVERS_ROOT;
+    if (!root || !existsSync(root)) {
+        console.warn(`[registry] MC_SERVERS_ROOT is not set or does not exist (got "${root}"). No servers discovered.`);
+        return [];
+    }
+
+    const isWindows = process.platform === 'win32';
+    const scriptFile = isWindows ? 'server_start.bat' : 'server_start.sh';
+    const scriptInvocation = isWindows ? 'server_start.bat' : './server_start.sh';
+
+    const configs = [];
+    const portsSeen = new Map();
+
+    for (const entry of readdirSync(root, { withFileTypes: true })) {
+        if (!entry.isDirectory()) continue;
+
+        const location = join(root, entry.name);
+        if (!existsSync(join(location, scriptFile))) {
+            console.warn(`[registry] Skipping "${entry.name}": no ${scriptFile} found.`);
+            continue;
+        }
+
+        const port = readServerPort(location);
+        const type = detectServerType(location);
+
+        if (portsSeen.has(port)) {
+            console.warn(`[registry] Port ${port} is shared between "${portsSeen.get(port)}" and "${entry.name}". Make sure only one runs at a time.`);
+        } else {
+            portsSeen.set(port, entry.name);
+        }
+
+        configs.push({
+            name: entry.name,
+            location,
+            scriptName: scriptInvocation,
+            port,
+            type,
+        });
+    }
+
+    return configs;
+}
+
+function readServerPort(serverDir) {
+    const propsPath = join(serverDir, 'server.properties');
+    if (!existsSync(propsPath)) return 25565;
+
+    try {
+        const contents = readFileSync(propsPath, 'utf8');
+        for (const rawLine of contents.split(/\r?\n/)) {
+            const line = rawLine.trim();
+            if (!line || line.startsWith('#')) continue;
+            const match = line.match(/^server-port\s*=\s*(\d+)$/);
+            if (match) return Number(match[1]);
+        }
+    } catch (err) {
+        console.warn(`[registry] Could not read ${propsPath}:`, err.message);
+    }
+    return 25565;
+}
+
+function detectServerType(serverDir) {
+    const entries = readdirSync(serverDir, { withFileTypes: true });
+
+    for (const entry of entries) {
+        if (entry.isFile()) {
+            if (/^forge-.*\.jar$/i.test(entry.name)) return 'modded';
+            if (entry.name === 'fabric-server-launch.jar') return 'modded';
+        }
+        if (entry.isDirectory() && entry.name === 'mods') {
+            const modsDir = join(serverDir, 'mods');
+            try {
+                const hasMods = readdirSync(modsDir).some(f => /\.(jar|jar\.disabled)$/i.test(f));
+                if (hasMods) return 'modded';
+            } catch { /* ignore */ }
+        }
+    }
+    return 'vanilla';
+}
+
+/**
+ * Builds the registry from discovery output. Wires a state-change callback so
+ * presence updates whenever any server transitions.
+ */
+export function initServerRegistry(client) {
+    if (!client?.user) {
+        throw new Error('Client is not ready. Server registry cannot initialize.');
+    }
+    botUser = client.user;
+
+    registry.clear();
+    for (const config of discoverServers()) {
+        registry.set(config.name, new MinecraftServer(config, refreshPresence));
+        console.log(`[registry] Loaded server "${config.name}" (${config.type}, port ${config.port}).`);
+    }
+
+    refreshPresence();
+}
+
+/**
+ * Re-runs discovery. Adds new folders, removes vanished ones (only if their
+ * server is not currently running). Existing entries are left untouched.
+ * @returns {{added: string[], removed: string[], orphaned: string[]}}
+ */
+export function reloadRegistry() {
+    const discovered = new Map(discoverServers().map(c => [c.name, c]));
+    const added = [];
+    const removed = [];
+    const orphaned = [];
+
+    for (const [name, config] of discovered) {
+        if (!registry.has(name)) {
+            registry.set(name, new MinecraftServer(config, refreshPresence));
+            added.push(name);
+        }
+    }
+
+    for (const name of [...registry.keys()]) {
+        if (discovered.has(name)) continue;
+        const server = registry.get(name);
+        if (server.isStopped()) {
+            registry.delete(name);
+            removed.push(name);
+        } else {
+            orphaned.push(name);
+        }
+    }
+
+    refreshPresence();
+    return { added, removed, orphaned };
+}
+
+export function getServer(name) {
+    return registry.get(name);
+}
+
+export function serverNames() {
+    return [...registry.keys()];
+}
+
+export function listServers() {
+    return [...registry.values()].map(s => {
+        const cfg = s.getConfig();
+        return { name: cfg.name, type: cfg.type, port: cfg.port, state: s.getState() };
+    });
+}
+
+function refreshPresence() {
+    if (!botUser) return;
+    setAggregatePresence(botUser, [...registry.values()]).catch(err => {
+        console.error('[registry] Failed to update presence:', err);
+    });
+}


### PR DESCRIPTION
Replaces the singleton MinecraftServer with a registry that scans MC_SERVERS_ROOT for subfolders and instantiates one MinecraftServer per discovered folder. Each server's type (vanilla/modded) and port are inferred from the folder contents and server.properties; modded servers use looser boot-output checks since Forge emits non-fatal errors during startup.

Existing slash commands (start-server, stop-server, execute, players) gain a required `server` argument with autocomplete sourced from the live registry. New /list-servers shows all configured servers with their state; /reload-servers re-scans the root folder so newly-added folders appear without a bot restart.

Bot presence is now an aggregate ("N/M running") computed by the registry whenever any server transitions state. The legacy MC_SERVER_SCRIPT_LOCATION and MC_SERVER_SCRIPT_NAME env vars are removed in favor of MC_SERVERS_ROOT; README documents the migration path.